### PR TITLE
Add caps_flags_test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_executable(capability_test capability_test.c)
 target_link_libraries(capability_test PRIVATE d3d8_to_gles)
 add_test(NAME capability_test COMMAND capability_test)
+
+add_executable(caps_flags_test caps_flags_test.c)
+target_link_libraries(caps_flags_test PRIVATE d3d8_to_gles)
+add_test(NAME caps_flags_test COMMAND caps_flags_test)

--- a/tests/caps_flags_test.c
+++ b/tests/caps_flags_test.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+#include <d3d8_to_gles.h>
+
+int main(void) {
+    IDirect3D8 *d3d = Direct3DCreate8(D3D_SDK_VERSION);
+    assert(d3d && "Failed to create D3D8 interface");
+
+    D3DCAPS8 caps;
+    HRESULT hr = d3d->lpVtbl->GetDeviceCaps(d3d, D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, &caps);
+    assert(hr == D3D_OK && "GetDeviceCaps failed");
+
+    /* Check texture capabilities */
+    assert(caps.TextureCaps & D3DPTEXTURECAPS_CUBEMAP);
+    /* Check for basic filter caps */
+    assert((caps.TextureFilterCaps & D3DPTFILTERCAPS_MAGFLINEAR) &&
+           (caps.TextureFilterCaps & D3DPTFILTERCAPS_MINFLINEAR));
+    /* Check rasterization capability */
+    assert(caps.DevCaps & D3DDEVCAPS_HWRASTERIZATION);
+    /* Confirm depth test support */
+    assert(caps.RasterCaps & D3DPRASTERCAPS_ZTEST);
+
+    d3d->lpVtbl->Release(d3d);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add caps_flags_test.c to assert presence of several capability flags
- register caps_flags_test with CMake
- keep existing testing hooks in main `CMakeLists.txt`
- adjust caps_flags_test to check supported flags

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest -V`


------
https://chatgpt.com/codex/tasks/task_e_6855b615adbc8325a01a839f6f85b837