### PR TITLE
Add box and sphere tests

### DIFF
--- a/include/d3d8_to_gles.h
+++ b/include/d3d8_to_gles.h
@@ -361,6 +361,7 @@ struct IDirect3DIndexBuffer8 {
 
 // D3DX function prototypes
 HRESULT WINAPI D3DXCreateBox(LPDIRECT3DDEVICE8 pDevice, FLOAT Width, FLOAT Height, FLOAT Depth, LPD3DXMESH *ppMesh, LPD3DXBUFFER *ppAdjacency);
+HRESULT WINAPI D3DXCreateSphere(LPDIRECT3DDEVICE8 pDevice, FLOAT Radius, UINT Slices, UINT Stacks, LPD3DXMESH *ppMesh, LPD3DXBUFFER *ppAdjacency);
 HRESULT WINAPI D3DXCreateBuffer(DWORD NumBytes, LPD3DXBUFFER *ppBuffer);
 HRESULT WINAPI D3DXGetErrorStringA(HRESULT hr, LPSTR pBuffer, UINT BufferLen);
 HRESULT WINAPI D3DXCreateMatrixStack(DWORD Flags, LPD3DXMATRIXSTACK *ppStack);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,3 +5,11 @@ add_test(NAME capability_test COMMAND capability_test)
 add_executable(caps_flags_test caps_flags_test.c)
 target_link_libraries(caps_flags_test PRIVATE d3d8_to_gles)
 add_test(NAME caps_flags_test COMMAND caps_flags_test)
+
+add_executable(box_render_test box_render_test.c)
+target_link_libraries(box_render_test PRIVATE d3d8_to_gles)
+add_test(NAME box_render_test COMMAND box_render_test)
+
+add_executable(sphere_stub_test sphere_stub_test.c)
+target_link_libraries(sphere_stub_test PRIVATE d3d8_to_gles)
+add_test(NAME sphere_stub_test COMMAND sphere_stub_test)

--- a/tests/box_render_test.c
+++ b/tests/box_render_test.c
@@ -1,0 +1,59 @@
+#include <assert.h>
+#include <d3d8_to_gles.h>
+#include <math.h>
+
+int main(void) {
+  IDirect3D8 *d3d = Direct3DCreate8(D3D_SDK_VERSION);
+  assert(d3d && "Failed to create D3D8 interface");
+
+  D3DPRESENT_PARAMETERS pp = {0};
+  pp.BackBufferWidth = 64;
+  pp.BackBufferHeight = 64;
+  pp.BackBufferFormat = D3DFMT_X8R8G8B8;
+  pp.BackBufferCount = 1;
+  pp.MultiSampleType = D3DMULTISAMPLE_NONE;
+  pp.SwapEffect = D3DSWAPEFFECT_DISCARD;
+  pp.hDeviceWindow = 0;
+  pp.Windowed = TRUE;
+  pp.EnableAutoDepthStencil = FALSE;
+  pp.Flags = 0;
+  pp.FullScreen_RefreshRateInHz = 0;
+  pp.FullScreen_PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;
+
+  IDirect3DDevice8 *device = NULL;
+  HRESULT hr =
+      d3d->lpVtbl->CreateDevice(d3d, D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL,
+                                pp.hDeviceWindow, 0, &pp, &device);
+  assert(hr == D3D_OK && "CreateDevice failed");
+
+  ID3DXMesh *mesh = NULL;
+  hr = D3DXCreateBox(device, 1.0f, 1.0f, 1.0f, &mesh, NULL);
+  assert(hr == D3D_OK && "D3DXCreateBox failed");
+
+  D3DXMATRIX view, proj;
+  D3DXVECTOR3 eye = {0.0f, 0.0f, -5.0f};
+  D3DXVECTOR3 at = {0.0f, 0.0f, 0.0f};
+  D3DXVECTOR3 up = {0.0f, 1.0f, 0.0f};
+  D3DXMatrixLookAtLH(&view, &eye, &at, &up);
+  hr = device->lpVtbl->SetTransform(device, D3DTS_VIEW, &view);
+  assert(hr == D3D_OK && "SetTransform view failed");
+
+  D3DXMatrixPerspectiveFovLH(&proj, (FLOAT)(45.0 * (M_PI / 180.0)), 1.0f, 1.0f,
+                             10.0f);
+  hr = device->lpVtbl->SetTransform(device, D3DTS_PROJECTION, &proj);
+  assert(hr == D3D_OK && "SetTransform projection failed");
+
+  hr = device->lpVtbl->BeginScene(device);
+  assert(hr == D3D_OK && "BeginScene failed");
+
+  hr = mesh->pVtbl->DrawSubset(mesh, 0);
+  assert(hr == D3D_OK && "DrawSubset failed");
+
+  hr = device->lpVtbl->EndScene(device);
+  assert(hr == D3D_OK && "EndScene failed");
+
+  mesh->pVtbl->Release(mesh);
+  device->lpVtbl->Release(device);
+  d3d->lpVtbl->Release(d3d);
+  return 0;
+}

--- a/tests/sphere_stub_test.c
+++ b/tests/sphere_stub_test.c
@@ -1,0 +1,8 @@
+#include <assert.h>
+#include <d3d8_to_gles.h>
+
+int main(void) {
+  HRESULT hr = D3DXCreateSphere(NULL, 1.0f, 8, 8, NULL, NULL);
+  assert(hr == D3DXERR_NOTAVAILABLE);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add D3DXCreateSphere prototype
- test rendering a box mesh
- test stubbed D3DXCreateSphere call
- build the new tests with CMake

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest -V` *(fails: box_render_test assertion)*

------
https://chatgpt.com/codex/tasks/task_e_6855cab805888325bf9f85d4f1c73683