### PR TITLE
Support extra FVF bits

### DIFF
--- a/include/d3d8_defs.h
+++ b/include/d3d8_defs.h
@@ -452,8 +452,11 @@ typedef struct _D3DCAPS8 {
 #define D3DFVF_XYZ    0x002
 #define D3DFVF_NORMAL 0x010
 #define D3DFVF_DIFFUSE 0x040
+#define D3DFVF_SPECULAR 0x080
 #define D3DFVF_TEX1   0x100
+#define D3DFVF_TEX2   0x200
 #define D3DFVF_TEXCOUNT_MASK 0xF00
+#define D3DFVF_TEXCOUNT_SHIFT 8
 
 #define D3DVSD_STREAM(_StreamNumber) ((DWORD)((0 << 29) | (_StreamNumber)))
 #define D3DVSD_REG(_VertexRegister, _Type) \
@@ -466,7 +469,9 @@ typedef struct _D3DCAPS8 {
 #define D3DVSDE_POSITION 0
 #define D3DVSDE_NORMAL   3
 #define D3DVSDE_DIFFUSE  5
+#define D3DVSDE_SPECULAR 6
 #define D3DVSDE_TEXCOORD0 7
+#define D3DVSDE_TEXCOORD1 8
 
 #define D3DUSAGE_WRITEONLY    0x00000008L
 #define D3DUSAGE_DYNAMIC      0x00000200L

--- a/src/d3d8_to_gles.c
+++ b/src/d3d8_to_gles.c
@@ -283,6 +283,7 @@ static void d3d_to_gl_matrix(GLfloat *gl_matrix, const D3DXMATRIX *d3d_matrix) {
 // Helper: Setup vertex attributes based on FVF
 static void setup_vertex_attributes(DWORD fvf, BYTE *data, UINT stride) {
     GLint offset = 0;
+
     if (fvf & D3DFVF_XYZ) {
         glEnableClientState(GL_VERTEX_ARRAY);
         glVertexPointer(3, GL_FLOAT, stride, data + offset);
@@ -290,6 +291,7 @@ static void setup_vertex_attributes(DWORD fvf, BYTE *data, UINT stride) {
     } else {
         glDisableClientState(GL_VERTEX_ARRAY);
     }
+
     if (fvf & D3DFVF_NORMAL) {
         glEnableClientState(GL_NORMAL_ARRAY);
         glNormalPointer(GL_FLOAT, stride, data + offset);
@@ -297,6 +299,7 @@ static void setup_vertex_attributes(DWORD fvf, BYTE *data, UINT stride) {
     } else {
         glDisableClientState(GL_NORMAL_ARRAY);
     }
+
     if (fvf & D3DFVF_DIFFUSE) {
         glEnableClientState(GL_COLOR_ARRAY);
         glColorPointer(4, GL_UNSIGNED_BYTE, stride, data + offset);
@@ -304,13 +307,24 @@ static void setup_vertex_attributes(DWORD fvf, BYTE *data, UINT stride) {
     } else {
         glDisableClientState(GL_COLOR_ARRAY);
     }
-    if (fvf & D3DFVF_TEX1) {
+
+    if (fvf & D3DFVF_SPECULAR) {
+        /* Skip specular color for now; GL ES 1.1 lacks secondary color arrays */
+        offset += 4;
+    }
+
+    int tex_count = (fvf & D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT;
+    for (int i = 0; i < tex_count && i < 2; i++) {
+        glClientActiveTexture(GL_TEXTURE0 + i);
         glEnableClientState(GL_TEXTURE_COORD_ARRAY);
         glTexCoordPointer(2, GL_FLOAT, stride, data + offset);
         offset += 8;
-    } else {
+    }
+    for (int i = tex_count; i < 2; i++) {
+        glClientActiveTexture(GL_TEXTURE0 + i);
         glDisableClientState(GL_TEXTURE_COORD_ARRAY);
     }
+    glClientActiveTexture(GL_TEXTURE0);
 }
 
 // Math functions
@@ -1359,20 +1373,26 @@ static DWORD d3dx_buffer_get_buffer_size(ID3DXBuffer *This) {
 UINT WINAPI D3DXGetFVFVertexSize(DWORD FVF) {
     if (!(FVF & D3DFVF_XYZ)) return 0;
 
-    if (FVF & ~(D3DFVF_XYZ | D3DFVF_NORMAL | D3DFVF_DIFFUSE | D3DFVF_TEX1))
+    if (FVF & ~(D3DFVF_XYZ | D3DFVF_NORMAL | D3DFVF_DIFFUSE | D3DFVF_SPECULAR |
+                 D3DFVF_TEX1 | D3DFVF_TEX2))
         return 0;
 
     UINT size = 3 * sizeof(float);
     if (FVF & D3DFVF_NORMAL) size += 3 * sizeof(float);
     if (FVF & D3DFVF_DIFFUSE) size += sizeof(DWORD);
-    if (FVF & D3DFVF_TEX1) size += 2 * sizeof(float);
+    if (FVF & D3DFVF_SPECULAR) size += sizeof(DWORD);
+
+    UINT tex_count = (FVF & D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT;
+    if (tex_count > 2) return 0;
+    size += tex_count * 2 * sizeof(float);
     return size;
 }
 
 HRESULT WINAPI D3DXDeclaratorFromFVF(DWORD FVF,
                                      DWORD Declaration[MAX_FVF_DECL_SIZE]) {
     if (!(FVF & D3DFVF_XYZ)) return D3DERR_INVALIDCALL;
-    if (FVF & ~(D3DFVF_XYZ | D3DFVF_NORMAL | D3DFVF_DIFFUSE | D3DFVF_TEX1))
+    if (FVF & ~(D3DFVF_XYZ | D3DFVF_NORMAL | D3DFVF_DIFFUSE | D3DFVF_SPECULAR |
+                D3DFVF_TEX1 | D3DFVF_TEX2))
         return D3DERR_INVALIDCALL;
 
     int i = 0;
@@ -1382,8 +1402,14 @@ HRESULT WINAPI D3DXDeclaratorFromFVF(DWORD FVF,
         Declaration[i++] = D3DVSD_REG(D3DVSDE_NORMAL, D3DVSDT_FLOAT3);
     if (FVF & D3DFVF_DIFFUSE)
         Declaration[i++] = D3DVSD_REG(D3DVSDE_DIFFUSE, D3DVSDT_D3DCOLOR);
-    if (FVF & D3DFVF_TEX1)
+    if (FVF & D3DFVF_SPECULAR)
+        Declaration[i++] = D3DVSD_REG(D3DVSDE_SPECULAR, D3DVSDT_D3DCOLOR);
+
+    UINT tex_count = (FVF & D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT;
+    if (tex_count > 0)
         Declaration[i++] = D3DVSD_REG(D3DVSDE_TEXCOORD0, D3DVSDT_FLOAT2);
+    if (tex_count > 1)
+        Declaration[i++] = D3DVSD_REG(D3DVSDE_TEXCOORD1, D3DVSDT_FLOAT2);
     Declaration[i++] = D3DVSD_END();
 
     for (; i < MAX_FVF_DECL_SIZE; i++) Declaration[i] = D3DVSD_END();


### PR DESCRIPTION
## Summary
- extend FVF definitions to cover specular color and up to two texture sets
- configure vertex setup to enable arrays based on new FVF bits
- update helpers that interpret FVF codes

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest -V` *(fails: box_render_test, sphere_stub_test)*

------
https://chatgpt.com/codex/tasks/task_e_68561090bcc08325b59013cbd651226f