### PR TITLE
Add cylinder and texture stage tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,3 +13,11 @@ add_test(NAME box_render_test COMMAND box_render_test)
 add_executable(sphere_stub_test sphere_stub_test.c)
 target_link_libraries(sphere_stub_test PRIVATE d3d8_to_gles)
 add_test(NAME sphere_stub_test COMMAND sphere_stub_test)
+
+add_executable(cylinder_stub_test cylinder_stub_test.c)
+target_link_libraries(cylinder_stub_test PRIVATE d3d8_to_gles)
+add_test(NAME cylinder_stub_test COMMAND cylinder_stub_test)
+
+add_executable(texture_stage_test texture_stage_test.c)
+target_link_libraries(texture_stage_test PRIVATE d3d8_to_gles)
+add_test(NAME texture_stage_test COMMAND texture_stage_test)

--- a/tests/cylinder_stub_test.c
+++ b/tests/cylinder_stub_test.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+#include <d3d8_to_gles.h>
+
+/* Prototype is not declared in the public header */
+HRESULT WINAPI D3DXCreateCylinder(LPDIRECT3DDEVICE8 pDevice,
+                                  FLOAT Radius1,
+                                  FLOAT Radius2,
+                                  FLOAT Length,
+                                  UINT Slices,
+                                  UINT Stacks,
+                                  LPD3DXMESH *ppMesh,
+                                  LPD3DXBUFFER *ppAdjacency);
+
+int main(void) {
+    HRESULT hr = D3DXCreateCylinder(NULL, 1.0f, 1.0f, 1.0f, 8, 1, NULL, NULL);
+    assert(hr == D3DXERR_NOTAVAILABLE);
+    return 0;
+}

--- a/tests/sphere_stub_test.c
+++ b/tests/sphere_stub_test.c
@@ -2,7 +2,43 @@
 #include <d3d8_to_gles.h>
 
 int main(void) {
-  HRESULT hr = D3DXCreateSphere(NULL, 1.0f, 8, 8, NULL, NULL);
-  assert(hr == D3DXERR_NOTAVAILABLE);
-  return 0;
+    /* Invalid parameter checks */
+    HRESULT hr = D3DXCreateSphere(NULL, 1.0f, 8, 8, NULL, NULL);
+    assert(hr == D3DERR_INVALIDCALL);
+
+    hr = D3DXCreateSphere(NULL, -1.0f, 8, 8, NULL, NULL);
+    assert(hr == D3DERR_INVALIDCALL);
+
+    hr = D3DXCreateSphere(NULL, 1.0f, 2, 8, NULL, NULL);
+    assert(hr == D3DERR_INVALIDCALL);
+
+    hr = D3DXCreateSphere(NULL, 1.0f, 8, 1, NULL, NULL);
+    assert(hr == D3DERR_INVALIDCALL);
+
+    IDirect3D8 *d3d = Direct3DCreate8(D3D_SDK_VERSION);
+    assert(d3d && "Failed to create D3D8 interface");
+
+    D3DPRESENT_PARAMETERS pp = {0};
+    pp.BackBufferWidth = 8;
+    pp.BackBufferHeight = 8;
+    pp.BackBufferFormat = D3DFMT_X8R8G8B8;
+    pp.BackBufferCount = 1;
+    pp.SwapEffect = D3DSWAPEFFECT_DISCARD;
+    pp.hDeviceWindow = 0;
+    pp.Windowed = TRUE;
+    pp.EnableAutoDepthStencil = FALSE;
+    pp.FullScreen_PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;
+
+    IDirect3DDevice8 *device = NULL;
+    hr = d3d->lpVtbl->CreateDevice(d3d, D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, pp.hDeviceWindow, 0, &pp, &device);
+    assert(hr == D3D_OK && "CreateDevice failed");
+
+    ID3DXMesh *mesh = NULL;
+    hr = D3DXCreateSphere(device, 1.0f, 8, 8, &mesh, NULL);
+    assert(hr == D3D_OK && mesh && "D3DXCreateSphere failed");
+
+    mesh->pVtbl->Release(mesh);
+    device->lpVtbl->Release(device);
+    d3d->lpVtbl->Release(d3d);
+    return 0;
 }

--- a/tests/texture_stage_test.c
+++ b/tests/texture_stage_test.c
@@ -1,0 +1,43 @@
+#include <assert.h>
+#include <d3d8_to_gles.h>
+
+int main(void) {
+    IDirect3D8 *d3d = Direct3DCreate8(D3D_SDK_VERSION);
+    assert(d3d && "Failed to create D3D8 interface");
+
+    D3DPRESENT_PARAMETERS pp = {0};
+    pp.BackBufferWidth = 8;
+    pp.BackBufferHeight = 8;
+    pp.BackBufferFormat = D3DFMT_X8R8G8B8;
+    pp.BackBufferCount = 1;
+    pp.SwapEffect = D3DSWAPEFFECT_DISCARD;
+    pp.hDeviceWindow = 0;
+    pp.Windowed = TRUE;
+    pp.EnableAutoDepthStencil = FALSE;
+    pp.FullScreen_PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;
+
+    IDirect3DDevice8 *device = NULL;
+    HRESULT hr = d3d->lpVtbl->CreateDevice(d3d, D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, pp.hDeviceWindow, 0, &pp, &device);
+    assert(hr == D3D_OK && "CreateDevice failed");
+
+    IDirect3DTexture8 *tex = NULL;
+    hr = device->lpVtbl->CreateTexture(device, 4, 4, 1, 0, D3DFMT_A8R8G8B8, D3DPOOL_MANAGED, &tex);
+    assert(hr == D3D_OK && "CreateTexture failed");
+
+    hr = device->lpVtbl->SetTexture(device, 0, tex);
+    assert(hr == D3D_OK && "SetTexture failed");
+
+    hr = device->lpVtbl->SetTextureStageState(device, 0, D3DTSS_COLOROP, D3DTOP_MODULATE);
+    assert(hr == D3D_OK && "SetTextureStageState COLOROP failed");
+
+    hr = device->lpVtbl->SetTextureStageState(device, 0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
+    assert(hr == D3D_OK && "SetTextureStageState COLORARG1 failed");
+
+    hr = device->lpVtbl->SetTextureStageState(device, 1, D3DTSS_COLOROP, D3DTOP_MODULATE);
+    assert(hr == D3DERR_INVALIDCALL && "Stage1 should fail");
+
+    tex->lpVtbl->Release(tex);
+    device->lpVtbl->Release(device);
+    d3d->lpVtbl->Release(d3d);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- expand sphere test with success and failure cases
- add cylinder and texture stage state tests
- build new tests in CMake

## Testing
- `cmake ..`
- `make -j4`
- `ctest -V` *(fails: box_render_test, sphere_stub_test, texture_stage_test due to device creation failure)*

------
https://chatgpt.com/codex/tasks/task_e_685614d7340c8325a9c68589a7162bab