### PR TITLE
Implement adapter enumeration stubs

### DIFF
--- a/src/d3d8_to_gles.c
+++ b/src/d3d8_to_gles.c
@@ -104,6 +104,9 @@ static DWORD d3dx_buffer_get_buffer_size(ID3DXBuffer *This);
 UINT WINAPI D3DXGetFVFVertexSize(DWORD FVF);
 HRESULT WINAPI D3DXDeclaratorFromFVF(DWORD FVF, DWORD Declaration[MAX_FVF_DECL_SIZE]);
 
+// Last created device's display mode for adapter queries
+static D3DDISPLAYMODE g_current_display_mode;
+
 static float dword_to_float(DWORD v) {
     union {
         DWORD d;
@@ -946,9 +949,31 @@ static const IDirect3DDevice8Vtbl device_vtbl = {
 };
 static HRESULT D3DAPI d3d8_register_software_device(IDirect3D8 *This, void *pInitializeFunction) { return D3DERR_NOTAVAILABLE; }
 static UINT D3DAPI d3d8_get_adapter_count(IDirect3D8 *This) { return 1; }
-static HRESULT D3DAPI d3d8_get_adapter_identifier(IDirect3D8 *This, UINT Adapter, DWORD Flags, D3DADAPTER_IDENTIFIER8 *pIdentifier) { return D3DERR_NOTAVAILABLE; }
+static HRESULT D3DAPI d3d8_get_adapter_identifier(IDirect3D8 *This,
+                                                  UINT Adapter,
+                                                  DWORD Flags,
+                                                  D3DADAPTER_IDENTIFIER8 *pIdentifier) {
+    if (Adapter != D3DADAPTER_DEFAULT || !pIdentifier) return D3DERR_INVALIDCALL;
+
+    memset(pIdentifier, 0, sizeof(*pIdentifier));
+    strncpy(pIdentifier->Driver, "d3d8_to_gles", sizeof(pIdentifier->Driver) - 1);
+
+    const char *vendor = (const char *)glGetString(GL_VENDOR);
+    if (!vendor) vendor = "Unknown";
+    strncpy(pIdentifier->Description, vendor, sizeof(pIdentifier->Description) - 1);
+
+    return D3D_OK;
+}
 static UINT D3DAPI d3d8_get_adapter_mode_count(IDirect3D8 *This, UINT Adapter) { return 1; }
-static HRESULT D3DAPI d3d8_enum_adapter_modes(IDirect3D8 *This, UINT Adapter, UINT Mode, D3DDISPLAYMODE *pMode) { return D3DERR_NOTAVAILABLE; }
+static HRESULT D3DAPI d3d8_enum_adapter_modes(IDirect3D8 *This,
+                                              UINT Adapter,
+                                              UINT Mode,
+                                              D3DDISPLAYMODE *pMode) {
+    if (Adapter != D3DADAPTER_DEFAULT || Mode > 0 || !pMode) return D3DERR_INVALIDCALL;
+
+    *pMode = g_current_display_mode;
+    return D3D_OK;
+}
 static HRESULT D3DAPI d3d8_get_adapter_display_mode(IDirect3D8 *This, UINT Adapter, D3DDISPLAYMODE *pMode) { return D3DERR_NOTAVAILABLE; }
 static HRESULT D3DAPI d3d8_check_device_type(IDirect3D8 *This, UINT Adapter, D3DDEVTYPE CheckType, D3DFORMAT DisplayFormat, D3DFORMAT BackBufferFormat, BOOL Windowed) { return D3D_OK; }
 static HRESULT D3DAPI d3d8_check_device_format(IDirect3D8 *This, UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, DWORD Usage, D3DRESOURCETYPE RType, D3DFORMAT CheckFormat) { return D3D_OK; }
@@ -1023,6 +1048,8 @@ static HRESULT D3DAPI d3d8_create_device(IDirect3D8 *This, UINT Adapter, D3DDEVT
     gles->display_mode.Height = pPresentationParameters->BackBufferHeight;
     gles->display_mode.Format = pPresentationParameters->BackBufferFormat;
     gles->display_mode.RefreshRate = pPresentationParameters->FullScreen_RefreshRateInHz;
+
+    g_current_display_mode = gles->display_mode;
 
     IDirect3DDevice8 *device = calloc(1, sizeof(IDirect3DDevice8) + sizeof(IDirect3DDevice8Vtbl));
     if (!device) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,3 +33,7 @@ add_test(NAME stencil_enable_test COMMAND stencil_enable_test)
 add_executable(xyzrhw_test xyzrhw_test.c)
 target_link_libraries(xyzrhw_test PRIVATE d3d8_to_gles)
 add_test(NAME xyzrhw_test COMMAND xyzrhw_test)
+
+add_executable(adapter_info_test adapter_info_test.c)
+target_link_libraries(adapter_info_test PRIVATE d3d8_to_gles)
+add_test(NAME adapter_info_test COMMAND adapter_info_test)

--- a/tests/adapter_info_test.c
+++ b/tests/adapter_info_test.c
@@ -1,0 +1,43 @@
+#include <assert.h>
+#include <d3d8_to_gles.h>
+#include <string.h>
+
+int main(void) {
+    IDirect3D8 *d3d = Direct3DCreate8(D3D_SDK_VERSION);
+    assert(d3d && "Failed to create D3D8 interface");
+
+    D3DPRESENT_PARAMETERS pp = {0};
+    pp.BackBufferWidth = 8;
+    pp.BackBufferHeight = 8;
+    pp.BackBufferFormat = D3DFMT_X8R8G8B8;
+    pp.BackBufferCount = 1;
+    pp.SwapEffect = D3DSWAPEFFECT_DISCARD;
+    pp.hDeviceWindow = 0;
+    pp.Windowed = TRUE;
+    pp.EnableAutoDepthStencil = FALSE;
+    pp.FullScreen_PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;
+
+    IDirect3DDevice8 *device = NULL;
+    HRESULT hr = d3d->lpVtbl->CreateDevice(d3d, D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL,
+                                           pp.hDeviceWindow, 0, &pp, &device);
+    assert(hr == D3D_OK && "CreateDevice failed");
+
+    D3DADAPTER_IDENTIFIER8 ident;
+    hr = d3d->lpVtbl->GetAdapterIdentifier(d3d, D3DADAPTER_DEFAULT, 0, &ident);
+    assert(hr == D3D_OK && "GetAdapterIdentifier failed");
+    const char *vendor = (const char *)glGetString(GL_VENDOR);
+    assert(vendor && "glGetString failed");
+    assert(strcmp(ident.Description, vendor) == 0);
+
+    D3DDISPLAYMODE mode;
+    hr = d3d->lpVtbl->EnumAdapterModes(d3d, D3DADAPTER_DEFAULT, 0, &mode);
+    assert(hr == D3D_OK && "EnumAdapterModes failed");
+    assert(mode.Width == pp.BackBufferWidth);
+    assert(mode.Height == pp.BackBufferHeight);
+    assert(mode.Format == pp.BackBufferFormat);
+    assert(mode.RefreshRate == pp.FullScreen_RefreshRateInHz);
+
+    device->lpVtbl->Release(device);
+    d3d->lpVtbl->Release(d3d);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- expose current display mode through global state
- fill `GetAdapterIdentifier` using GL vendor string
- return active backbuffer format from `EnumAdapterModes`
- add adapter info regression test

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest -V` *(fails: box_render_test, sphere_stub_test, texture_stage_test, color_write_mask_test, stencil_enable_test, xyzrhw_test, adapter_info_test)*

------
https://chatgpt.com/codex/tasks/task_e_68561f9e99b48325991ce1723812b9ba