### PR TITLE
Add color mask and stencil draw tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ developing or verifying the shim’s interfaces. The shim is compiled only
 against the headers in `include/` and does **not** use the SDK headers when
 building.
 
+## Tests
+Unit tests reside in the `tests/` directory and can be executed with `ctest`.
+Recent additions cover color write masks via `D3DRS_COLORWRITEENABLE` and
+basic stencil operations with a masked draw.
+
 ## Contributing
 See `AGENTS.md` for guidance on extending the shim, especially for AI-assisted contributions. Key areas for improvement:
 - Implement additional D3DX shapes (e.g., `D3DXCreateSphere`).

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,3 +45,11 @@ add_test(NAME tex2_coord_test COMMAND tex2_coord_test)
 add_executable(texcoord_index_test texcoord_index_test.c)
 target_link_libraries(texcoord_index_test PRIVATE d3d8_to_gles)
 add_test(NAME texcoord_index_test COMMAND texcoord_index_test)
+
+add_executable(color_mask_draw_test color_mask_draw_test.c)
+target_link_libraries(color_mask_draw_test PRIVATE d3d8_to_gles)
+add_test(NAME color_mask_draw_test COMMAND color_mask_draw_test)
+
+add_executable(stencil_mask_draw_test stencil_mask_draw_test.c)
+target_link_libraries(stencil_mask_draw_test PRIVATE d3d8_to_gles)
+add_test(NAME stencil_mask_draw_test COMMAND stencil_mask_draw_test)

--- a/tests/color_mask_draw_test.c
+++ b/tests/color_mask_draw_test.c
@@ -1,0 +1,56 @@
+#include <assert.h>
+#include <d3d8_to_gles.h>
+#include <string.h>
+
+int main(void) {
+    IDirect3D8 *d3d = Direct3DCreate8(D3D_SDK_VERSION);
+    assert(d3d && "Failed to create D3D8 interface");
+
+    D3DPRESENT_PARAMETERS pp = {0};
+    pp.BackBufferWidth = 1;
+    pp.BackBufferHeight = 1;
+    pp.BackBufferFormat = D3DFMT_X8R8G8B8;
+    pp.BackBufferCount = 1;
+    pp.SwapEffect = D3DSWAPEFFECT_DISCARD;
+    pp.hDeviceWindow = 0;
+    pp.Windowed = TRUE;
+    pp.EnableAutoDepthStencil = FALSE;
+    pp.FullScreen_PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;
+
+    IDirect3DDevice8 *device = NULL;
+    HRESULT hr = d3d->lpVtbl->CreateDevice(d3d, D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL,
+                                           pp.hDeviceWindow, 0, &pp, &device);
+    assert(hr == D3D_OK && "CreateDevice failed");
+
+    /* Clear the buffer to black with all channels enabled */
+    hr = device->lpVtbl->SetRenderState(device, D3DRS_COLORWRITEENABLE,
+                                        D3DCOLORWRITEENABLE_RED |
+                                        D3DCOLORWRITEENABLE_GREEN |
+                                        D3DCOLORWRITEENABLE_BLUE |
+                                        D3DCOLORWRITEENABLE_ALPHA);
+    assert(hr == D3D_OK);
+    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    /* Enable only red writes and clear to white */
+    hr = device->lpVtbl->SetRenderState(device, D3DRS_COLORWRITEENABLE,
+                                        D3DCOLORWRITEENABLE_RED);
+    assert(hr == D3D_OK);
+    glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    /* Restore mask and verify pixel value */
+    hr = device->lpVtbl->SetRenderState(device, D3DRS_COLORWRITEENABLE,
+                                        D3DCOLORWRITEENABLE_RED |
+                                        D3DCOLORWRITEENABLE_GREEN |
+                                        D3DCOLORWRITEENABLE_BLUE |
+                                        D3DCOLORWRITEENABLE_ALPHA);
+    assert(hr == D3D_OK);
+    unsigned char pixel[4] = {0};
+    glReadPixels(0, 0, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, pixel);
+    assert(pixel[0] == 255 && pixel[1] == 0 && pixel[2] == 0);
+
+    device->lpVtbl->Release(device);
+    d3d->lpVtbl->Release(d3d);
+    return 0;
+}

--- a/tests/stencil_mask_draw_test.c
+++ b/tests/stencil_mask_draw_test.c
@@ -1,0 +1,86 @@
+#include <assert.h>
+#include <d3d8_to_gles.h>
+#include <string.h>
+
+int main(void) {
+    IDirect3D8 *d3d = Direct3DCreate8(D3D_SDK_VERSION);
+    assert(d3d && "Failed to create D3D8 interface");
+
+    D3DPRESENT_PARAMETERS pp = {0};
+    pp.BackBufferWidth = 2;
+    pp.BackBufferHeight = 1;
+    pp.BackBufferFormat = D3DFMT_X8R8G8B8;
+    pp.BackBufferCount = 1;
+    pp.SwapEffect = D3DSWAPEFFECT_DISCARD;
+    pp.hDeviceWindow = 0;
+    pp.Windowed = TRUE;
+    pp.EnableAutoDepthStencil = TRUE;
+    pp.FullScreen_PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;
+
+    IDirect3DDevice8 *device = NULL;
+    HRESULT hr = d3d->lpVtbl->CreateDevice(d3d, D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL,
+                                           pp.hDeviceWindow, 0, &pp, &device);
+    assert(hr == D3D_OK && "CreateDevice failed");
+
+    /* First pass: write stencil value 1 on left half */
+    hr = device->lpVtbl->SetRenderState(device, D3DRS_STENCILENABLE, TRUE);
+    assert(hr == D3D_OK);
+    hr = device->lpVtbl->SetRenderState(device, D3DRS_STENCILFUNC, D3DCMP_ALWAYS);
+    assert(hr == D3D_OK);
+    hr = device->lpVtbl->SetRenderState(device, D3DRS_STENCILREF, 1);
+    assert(hr == D3D_OK);
+    hr = device->lpVtbl->SetRenderState(device, D3DRS_STENCILPASS, D3DSTENCILOP_REPLACE);
+    assert(hr == D3D_OK);
+    hr = device->lpVtbl->SetRenderState(device, D3DRS_STENCILMASK, 0xFF);
+    assert(hr == D3D_OK);
+    hr = device->lpVtbl->SetRenderState(device, D3DRS_STENCILWRITEMASK, 0xFF);
+    assert(hr == D3D_OK);
+    hr = device->lpVtbl->SetRenderState(device, D3DRS_COLORWRITEENABLE, 0);
+    assert(hr == D3D_OK);
+
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClearStencil(0);
+    glClear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+
+    GLfloat mask_quad[] = {
+        -1.0f, -1.0f, 0.0f,
+         0.0f, -1.0f, 0.0f,
+        -1.0f,  1.0f, 0.0f,
+         0.0f,  1.0f, 0.0f,
+    };
+    glEnableClientState(GL_VERTEX_ARRAY);
+    glVertexPointer(3, GL_FLOAT, 0, mask_quad);
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+    /* Second pass: draw full quad with stencil test equal to 1 */
+    hr = device->lpVtbl->SetRenderState(device, D3DRS_COLORWRITEENABLE,
+                                        D3DCOLORWRITEENABLE_RED |
+                                        D3DCOLORWRITEENABLE_GREEN |
+                                        D3DCOLORWRITEENABLE_BLUE |
+                                        D3DCOLORWRITEENABLE_ALPHA);
+    assert(hr == D3D_OK);
+    hr = device->lpVtbl->SetRenderState(device, D3DRS_STENCILFUNC, D3DCMP_EQUAL);
+    assert(hr == D3D_OK);
+    hr = device->lpVtbl->SetRenderState(device, D3DRS_STENCILPASS, D3DSTENCILOP_KEEP);
+    assert(hr == D3D_OK);
+
+    GLfloat full_quad[] = {
+        -1.0f, -1.0f, 0.0f,
+         1.0f, -1.0f, 0.0f,
+        -1.0f,  1.0f, 0.0f,
+         1.0f,  1.0f, 0.0f,
+    };
+    glVertexPointer(3, GL_FLOAT, 0, full_quad);
+    glColor4f(0.0f, 1.0f, 0.0f, 1.0f);
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+    unsigned char pixels[8] = {0};
+    glReadPixels(0, 0, 2, 1, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+    assert(pixels[1] == 255 && pixels[0] == 0 && pixels[2] == 0); /* left pixel green */
+    assert(pixels[4] == 0 && pixels[5] == 0 && pixels[6] == 0);   /* right pixel black */
+
+    glDisableClientState(GL_VERTEX_ARRAY);
+    device->lpVtbl->Release(device);
+    d3d->lpVtbl->Release(d3d);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add test for drawing with D3DRS_COLORWRITEENABLE
- add stencil mask draw test
- list new tests in README
- register tests with CMake

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest -V` *(fails: CreateDevice failed for several tests)*

------
https://chatgpt.com/codex/tasks/task_e_685626326f508325b8ddb009ec8b4d0d