### PR TITLE
Fix EGL default display cast warnings

### DIFF
--- a/src/d3d8_to_gles.c
+++ b/src/d3d8_to_gles.c
@@ -1099,8 +1099,10 @@ static HRESULT D3DAPI d3d8_create_device(IDirect3D8 *This, UINT Adapter, D3DDEVT
 
     gles->display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
     if (!eglInitialize(gles->display, NULL, NULL)) {
-        gles->display = eglGetPlatformDisplay(EGL_PLATFORM_SURFACELESS_MESA,
-                                              EGL_DEFAULT_DISPLAY, NULL);
+        gles->display =
+            eglGetPlatformDisplay(EGL_PLATFORM_SURFACELESS_MESA,
+                                  (void *)(intptr_t)EGL_DEFAULT_DISPLAY,
+                                  NULL);
         if (!eglInitialize(gles->display, NULL, NULL)) {
             free(gles);
             return D3DERR_INVALIDCALL;

--- a/tools/egl_config_cli.c
+++ b/tools/egl_config_cli.c
@@ -94,12 +94,16 @@ int main(int argc, char **argv) {
   if (getenv("DISPLAY")) {
     display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
     if (!eglInitialize(display, NULL, NULL)) {
-      display = eglGetPlatformDisplay(EGL_PLATFORM_SURFACELESS_MESA,
-                                      EGL_DEFAULT_DISPLAY, NULL);
+      display = eglGetPlatformDisplay(
+          EGL_PLATFORM_SURFACELESS_MESA,
+          (void *)(intptr_t)EGL_DEFAULT_DISPLAY,
+          NULL);
     }
   } else {
-    display = eglGetPlatformDisplay(EGL_PLATFORM_SURFACELESS_MESA,
-                                    EGL_DEFAULT_DISPLAY, NULL);
+    display = eglGetPlatformDisplay(
+        EGL_PLATFORM_SURFACELESS_MESA,
+        (void *)(intptr_t)EGL_DEFAULT_DISPLAY,
+        NULL);
   }
   if (!eglInitialize(display, NULL, NULL)) {
     fprintf(stderr, "Failed to initialize EGL\n");


### PR DESCRIPTION
## Summary
- fix clang warnings about `EGL_DEFAULT_DISPLAY`

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)`
- `ctest -V`

------
https://chatgpt.com/codex/tasks/task_e_6859e0b5fef883258d3f6ea6bc5e61f4